### PR TITLE
Fix FPS cap patch offsets

### DIFF
--- a/src/DisableFpsLimitsDllDirector.cpp
+++ b/src/DisableFpsLimitsDllDirector.cpp
@@ -71,9 +71,14 @@ namespace
 
 				logger.WriteLine(LogLevel::Info, "Attempting to overwrite memory");
 
-				OverwriteMemory(0x70244a, 0xFF);
-				OverwriteMemory(0x702457, 0xFF);
-				OverwriteMemory(0x702462, 0xFF);
+                                // Patch the immediate value for the MOV instructions that
+                                // set the FPS caps. The immediate value starts 6 bytes after
+                                // the beginning of each instruction, so we add the offset to
+                                // target the correct byte and avoid corrupting the opcode.
+
+                                OverwriteMemory(0x702450, 0xFF);
+                                OverwriteMemory(0x70245D, 0xFF);
+                                OverwriteMemory(0x702468, 0xFF);
 
 				logger.WriteLine(LogLevel::Info, "Disabled the FPS limits during simulation.");
 			}


### PR DESCRIPTION
## Summary
- correctly point memory overwrite to the immediate portion of FPS cap MOV instructions
- document offset adjustment to avoid corrupting opcodes

## Testing
- `xbuild src/SC4DisableFpsLimits.sln` *(fails: Ignoring vcproj 'SC4DisableFpsLimits')*


------
https://chatgpt.com/codex/tasks/task_e_68909cbe732c8325afd41689e900ddcd